### PR TITLE
Fix file name for fixing cloning on windows/macOS

### DIFF
--- a/Java-Visualizer/java/README.md
+++ b/Java-Visualizer/java/README.md
@@ -1,4 +1,4 @@
-In order for the traceprinter package to work, it needs a few java tools. 
+In order for the traceprinter package to work, it needs a few java tools.
 
 This was copied directly from David Pritchard's repository found at: 
 https://github.com/daveagp/java_jail


### PR DESCRIPTION
The commit diff seems weird, I know but the problem is not in the file data, but in the name of specific file.
Linux allows many file name rules that is a big no for Windows and MacOS. The file had a space after the extension name as you see in the image.
![image](https://user-images.githubusercontent.com/19334375/176320459-d33b387e-01d1-4860-9a91-9517ed425163.png)
This was making the repo unclonable on Windows.

For more details about it:
https://stackoverflow.com/a/61616948